### PR TITLE
Add an email asking about historic kit in the inventory

### DIFF
--- a/other/2019-05-06-volunteer-kit.txt
+++ b/other/2019-05-06-volunteer-kit.txt
@@ -1,0 +1,21 @@
+Hi,
+
+As you may be aware, Student Robotics returned for SR2019. Following that, we're
+trying to ensure that our records are up to date.
+
+You're receiving this email because our inventory system [1] records that you
+hold some (possibly historic) equipment. Please could you have a look in the
+inventory (the top level folders for people are named as first initial and
+surname) and check whether you still have the items it records.
+
+Don't worry if you no longer have the items; we appreciate that it may have been
+several years since you were involved in Student Robotics.
+
+Whether or not you still have the items, please let us know so that we can
+update our records. We'll then let you know what to do with any items you still
+have.
+
+Thanks,
+Peter
+
+[1]: https://github.com/srobo/inventory/

--- a/other/2019-05-06-volunteer-kit.txt
+++ b/other/2019-05-06-volunteer-kit.txt
@@ -1,3 +1,8 @@
+---
+subject: Historic Student Robotics assets
+to: Volunteers with historic kit according to the inventory
+---
+
 Hi,
 
 As you may be aware, Student Robotics returned for SR2019. Following that, we're

--- a/other/2019-05-06-volunteer-kit.txt
+++ b/other/2019-05-06-volunteer-kit.txt
@@ -1,6 +1,7 @@
 ---
 subject: Historic Student Robotics assets
 to: Volunteers with historic kit according to the inventory
+cc: core-team
 ---
 
 Hi,


### PR DESCRIPTION
I'm planning to send this directly from my @sr email address, with core-team@ and archive@ in the CC, using BCC for volunteers email addresses. The volunteers are those who (according to the inventory) have some SR things.

I'm not sending this to a few people who I know have recently updated their folders in the repo or have non-trivial amounts of current kit.

I am assuming that: if these volunteers reply that they no longer have the items, we're happy to just write-off the items as losses. (Most of the items are v3 kit or older, or various other items from that era, so I think this is reasonable) cc @richardbarlow mostly for input on whether the trustees would object to this.

Contributes to https://github.com/srobo/tasks/issues/173