### PR TITLE
Add email about game conclusion meeting

### DIFF
--- a/SR2020/2019-09-09-game-design-conclusion-meeting.md
+++ b/SR2020/2019-09-09-game-design-conclusion-meeting.md
@@ -1,0 +1,33 @@
+---
+to: All Volunteers
+subject: SR2020 Game Design Conclusion Meeting
+---
+
+Hello!
+
+On Saturday, we held a meeting to kickoff the process of defining the game for SR2020. We took some [rough notes](**REDACTED**) at this meeting, which resulted in 2 high-level games being decided on.
+
+# Next Steps
+
+In the next few days, the 2 games will have a high-level set of rules written, and opened as PRs against the [rules repo](https://github.com/srobo/rules) (This repo is only visible to those in the GitHub organisation. If you don't have access, message [Jake Howard (`@jhoward`)](https://studentrobotics.slack.com/messages/game) in Slack. (If you're not in our Slack, please do [join us](https://goo.gl/forms/Maq41MHF8CYSRVn83)!))
+
+Once these rules are published, anyone is welcome to review, comment, and submit feedback on these rules documents. We'll post the rules documents in [#game](https://studentrobotics.slack.com/messages/game), as well as links to the relevant PRs.
+
+If you already have a reasonably formed rules document for an alternative game, please feel free to submit that too!
+
+# Conclusion Meeting
+
+To decide the final set of rules we'll be using at SR2020, we're planning to run a conclusion meeting, to discuss the pros / cons of each of the suggested games, and finally decide which one we'll be using. The rules document may not be 100% final by the end of the meeting, but it should be close!
+
+The meeting will happen on Saturday 14th @ 14:00. We're hoping the meeting won't take much longer than an hour or two, but any time you can give is greatly appreciated - Feel free to come and go as you please! The meetings will be *very* informal, relaxed, and likely culminate in a social.
+
+As well as being a Google Meet call, the meeting will also be happening in 2 locations:
+
+- University of Southampton, [B16/2015](https://data.southampton.ac.uk/building/16.html)
+- The offices of [Thread](https://www.thread.com/) (1 Alie Street, London, E1 8DE)
+
+If you don't have access to these rooms, throw a message in [Slack](https://studentrobotics.slack.com/messages/events) when you arrive, and someone will let you in. (If you're not in our Slack, please do [join us](https://goo.gl/forms/Maq41MHF8CYSRVn83)!)
+
+The event, locations, and a link to the Google Meet call are available on the [Volunteer Calendar](https://calendar.google.com/calendar/embed?src=studentrobotics.org_oqdjasvpps8smo0d5nte417rak%40group.calendar.google.com&ctz=Europe%2FLondon).
+
+We hope to see you there!


### PR DESCRIPTION
After yesterday's meeting, we need to run another meeting to finally decide the rules document.

Venues have already been booked, and the calendar event created.


## Deployment notes
- Paste in the actual link to the 'rough notes' from the last meeting.