### PR TITLE
Document the process of sending an email.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ Log of emails to volunteers
 2. Add metadata to your email. This should specify who the email is being sent to, and the subject. Take a look at previous emails for formatting guidance.
 3. Fork this repo, and commit your email. The file should be named based on the _expected_ send date, in a directory corresponding to the competition cycle year.
 4. Request the PR be reviewed. Either by using the 'Reviewers' functionality in GitHub, or by sending a message in [#volunteering](https://studentrobotics.slack.com/messages/volunteering).
-5. Once the PR is approved, request it be sent. Currently this requires either [`@jhoward`](https://studentrobotics.slack.com/messages/jhoward) or [`@abarrett-sprot`](https://studentrobotics.slack.com/messages/abarrett-sprot) in Slack (improvements in progress).
+5. Once the PR is approved, request it be sent.
+    Currently this is a manual process -- ping either [`@jhoward`](https://studentrobotics.slack.com/messages/jhoward) or [`@abarrett-sprot`](https://studentrobotics.slack.com/messages/abarrett-sprot) in Slack (we hope to improve this in future).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # volunteer-emails
 Log of emails to volunteers
+
+## Sending an email to volunteers
+
+1. Write your email in [markdown](https://guides.github.com/features/mastering-markdown/).
+2. Add metadata to your email. This should specify who the email is being sent to, and the subject. Take a look at previous emails for formatting guidance.
+3. Fork this repo, and commit your email. The file should be named based on the _expected_ send date, in a directory corresponding to the competition cycle year.
+4. Request the PR be reviewed. Either by using the 'Reviewers' functionality in GitHub, or by sending a message in [#volunteering](https://studentrobotics.slack.com/messages/volunteering).
+5. Once the PR is approved, request it be sent. Currently this requires either [`@jhoward`](https://studentrobotics.slack.com/messages/jhoward) or [`@abarrett-sprot`](https://studentrobotics.slack.com/messages/abarrett-sprot) in Slack (improvements in progress).


### PR DESCRIPTION
Rather than have it undefined, we should document how to send emails.

IMO the documentation for how to use this repo should live with the repo, and the fact of its existence should go in the runbook, rather than putting everything in the runbook (https://github.com/srobo/runbook/pull/70).