### PR TITLE
Add Email Inviting Volenteers to Kit Sorting Day

### DIFF
--- a/SR2020/2019-09-24-kit-sorting-day.md
+++ b/SR2020/2019-09-24-kit-sorting-day.md
@@ -1,0 +1,13 @@
+---
+to: All Volunteers
+subject: SR2020 Kit Sorting Day Southampton
+---
+
+Hello!
+
+As you are probably all aware Kickstart is approching fast and this years kit needs to be sorted! To get all of this done a weekend of Kit Sorting is planned on the weekend of the **5-6th October** at the **University of Southampton**. 
+
+We really do need all the help we can get! So if you are in the area and willing to attend, even just one day, please reply to this email or message [Tom Wheal (`@tom.wheal`)](https://studentrobotics.slack.com/messages/kit-dev) on Slack! 
+
+(Broken Biscuits and Banging Tunes will be provided)
+We hope to see you there!

--- a/SR2020/2019-09-24-kit-sorting-day.md
+++ b/SR2020/2019-09-24-kit-sorting-day.md
@@ -5,9 +5,13 @@ subject: SR2020 Kit Sorting Day Southampton
 
 Hello!
 
-As many of you are aware, Kickstart is approching fast and this years kit needs to be sorted! To get all of this done a weekend of Kit Sorting is planned on the weekend of the **5-6th October** at the **University of Southampton**. 
+As many of you are aware, Kickstart is approaching fast and this years kit needs to be sorted! To get all of this done a weekend of Kit Sorting is planned on the weekend of the **5-6th October** at the **University of Southampton**. The exact room will be confirmed at a later date!
+
+The day will involve testing and fixing kit along with packing it up into boxes ready for kickstart, more information on this is available on the [Runbook](https://srobo.github.io/runbook/kit/hardware/kit-collation/).
 
 We really do need all the help we can get! So if you are in the area and willing to attend, even for just a few hours, please reply to this email or message [Tom Wheal (`@tom.wheal`)](https://studentrobotics.slack.com/messages/kit-dev) on Slack! 
+
+The event details and locations are available on the [Volunteer Calendar](https://calendar.google.com/calendar/embed?src=studentrobotics.org_oqdjasvpps8smo0d5nte417rak%40group.calendar.google.com&ctz=Europe%2FLondon).
 
 (Broken Biscuits and Banging Tunes will be provided)
 We hope to see you there!

--- a/SR2020/2019-09-24-kit-sorting-day.md
+++ b/SR2020/2019-09-24-kit-sorting-day.md
@@ -5,9 +5,9 @@ subject: SR2020 Kit Sorting Day Southampton
 
 Hello!
 
-As you are probably all aware Kickstart is approching fast and this years kit needs to be sorted! To get all of this done a weekend of Kit Sorting is planned on the weekend of the **5-6th October** at the **University of Southampton**. 
+As many of you are aware, Kickstart is approching fast and this years kit needs to be sorted! To get all of this done a weekend of Kit Sorting is planned on the weekend of the **5-6th October** at the **University of Southampton**. 
 
-We really do need all the help we can get! So if you are in the area and willing to attend, even just one day, please reply to this email or message [Tom Wheal (`@tom.wheal`)](https://studentrobotics.slack.com/messages/kit-dev) on Slack! 
+We really do need all the help we can get! So if you are in the area and willing to attend, even for just a few hours, please reply to this email or message [Tom Wheal (`@tom.wheal`)](https://studentrobotics.slack.com/messages/kit-dev) on Slack! 
 
 (Broken Biscuits and Banging Tunes will be provided)
 We hope to see you there!

--- a/SR2020/2019-09-24-kit-sorting-day.md
+++ b/SR2020/2019-09-24-kit-sorting-day.md
@@ -5,11 +5,11 @@ subject: SR2020 Kit Sorting Day Southampton
 
 Hello!
 
-As many of you are aware, Kickstart is approaching fast and this years kit needs to be sorted! To get all of this done a weekend of Kit Sorting is planned on the weekend of the **5-6th October** at the **University of Southampton**. The exact room will be confirmed at a later date!
+As many of you are aware, Kickstart is approaching fast and this years kit needs to be prepared for the students or they’ll have nothing to build their robots with! To get this done a weekend of Kit Sorting is planned on the **5-6th October** at the **University of Southampton** (You don’t need to be a university student to attend). The exact room will be confirmed at a later date.  
 
-The day will involve testing and fixing kit along with packing it up into boxes ready for kickstart, more information on this is available on the [Runbook](https://srobo.github.io/runbook/kit/hardware/kit-collation/).
+We will start organising everything from 9am with the main effort starting at 10am each day, so please show up by then. The weekend will involve testing and fixing kit along with packing it up into boxes ready for kickstart, however you don’t need any technical expertise to help. 
 
-We really do need all the help we can get! So if you are in the area and willing to attend, even for just a few hours, please reply to this email or message [Tom Wheal (`@tom.wheal`)](https://studentrobotics.slack.com/messages/kit-dev) on Slack! 
+We really do need all the help we can get! So if you are in the area and willing to attend, even for just a few hours, please let us know **as soon as you can** by replying to this email or messaging [Tom Wheal (`@tom.wheal`)](https://studentrobotics.slack.com/messages/kit-dev) on Slack.
 
 The event details and locations are available on the [Volunteer Calendar](https://calendar.google.com/calendar/embed?src=studentrobotics.org_oqdjasvpps8smo0d5nte417rak%40group.calendar.google.com&ctz=Europe%2FLondon).
 


### PR DESCRIPTION
This needs to be sent from the kit-committee email if possible. 