### PR TITLE
Add a november update email for volunteers

### DIFF
--- a/SR2020/2019-11-11-november-update.md
+++ b/SR2020/2019-11-11-november-update.md
@@ -1,0 +1,88 @@
+---
+to: All Volunteers
+subject: November Update
+---
+
+Hi all,
+
+Here's a roundup of all the things we're currently working on to make SR2020
+awesome. As ever, if you'd like to get involved please join us in our [Slack][slack]
+([signup form][slack-signup]).
+
+### Kickstart
+
+As you're probably aware, Kickstart happened at the end of October. A huge
+thank-you to those who helped out, either at one of the venues or with any of
+the preparation. It's much appreciated and helped the events run smoothly.
+
+### Supporting Teams
+
+With the competition year now started, we're organising Tech Days and team
+Mentoring in order to support the teams as they build their robots.
+
+#### Tech Days
+
+Tech Days are fairly casual events we host for the teams to spend a day working
+on their robots surrounded by volunteers and other teams. They are and are a
+great opportunity to meet and work with other volunteers as well as see how the
+teams are progressing. Tech Days are all day events (usually on a Saturday),
+though if you can only make a part of the day that's fine.
+
+There's no need to worry if you don't know much about the kit or the robots --
+Tech Days are a great place to learn about both by working alongside other
+volunteers. Just asking the teams to explain what they're working on and
+providing a friendly outside perspective is really helpful.
+
+The next Tech Day is in [London, on Saturday 30th November][london-tech-day] --
+if you'd like to help out, please sign up to **[help at the London Tech Day][tech-day-signup]**.
+
+Alternatively, if you think you would like to organise a Tech Day, please
+[email the Competition Team](mailto:competition-team@studentrobotics.org).
+
+#### Mentoring
+
+Mentoring is an opportunity for you to get to know a team and to grow your
+communication and team working skills, as well as help them improve their robot.
+
+Your role as a mentor is to guide the team towards good solutions for their
+robot, provide assistance where they might need it as well as help them
+understand the kit, the rules and the competition as a whole. This doesn't mean
+that you need to know everything about these yourself (it's completely fine not
+to know things!), rather you will guide them towards finding the information for
+themselves.
+
+We have some [guidance for mentors][mentor-guidance] in our runbook which we
+encourage all potential mentors to read and we will support you through the year.
+
+The time commitment for mentoring varies by team, though it is typical to spend
+a few hours every week or fortnight on a mentoring session. This includes travel
+time, though we won't ask you to travel further than you feel comfortable.
+
+If you'd like to get a feel for whether there are any teams near you that you
+might be able to visit, we have a [map of competing teams][teams-map].
+
+**[Sign up to mentor a team][mentoring-signup]**.
+
+### Competition Planning
+
+Planning for the competition is now well under way. The competition team are
+currently considering two potential venues:
+ * University of Reading
+ * University of Southampton
+
+Over the next few weeks we'll also be creating a list of the tasks which need
+doing in order to make the competition happen. If you'd like to get involved
+(even small contributions really help), please [join us][slack-signup] in our
+[Slack][slack].
+
+
+-- The SR Competition Team
+
+
+[slack]: https://studentrobotics.slack.com
+[slack-signup]: https://goo.gl/forms/Maq41MHF8CYSRVn83
+[london-tech-day]: https://studentrobotics.org/events/sr2020/london-tech-day-november/
+[tech-day-signup]: https://forms.gle/isHzxAkd7HKKFWGR9
+[mentoring-signup]: https://forms.gle/isHzxAkd7HKKFWGR9
+[mentor-guidance]: https://srobo.github.io/runbook/volunteering/mentor-guidance/
+[teams-map]: https://drive.google.com/a/studentrobotics.org/open?id=1vEwB5vYNA-KJDnatYtwm7qD9Ewkccd9u

--- a/SR2020/2019-11-11-november-update.md
+++ b/SR2020/2019-11-11-november-update.md
@@ -11,9 +11,22 @@ awesome. As ever, if you’d like to get involved please join us in our [Slack][
 
 ### Kickstart
 
-As you’re probably aware, Kickstart happened at the end of October. A huge
-thank-you to those who helped out, either at one of the venues or with any of
-the preparation. It’s much appreciated and helped the events run smoothly.
+As you’re probably aware, Kickstart happened at the end of October. At the
+event, which was held simultaneously in three locations, we
+[announced][game-announcement-post] this year's game to the twenty-nine teams
+who attended in person.
+
+Our game this year, _Two Colours_, challenges teams to score points by
+retrieving coloured tokens from on and around a raised platform in the centre of
+the arena. They must place these tokens within their scoring zone (i.e. their
+corner of the arena). However, if a team gathers more than one token colour
+within their scoring zone, each token's value drops from 3 points to 1 point.
+Full details, including the prizes available this year, are available in the
+[rulebook][two-colours-rules].
+
+A huge thank-you to those who helped out, either at one of the venues or with
+any of the preparation. It’s much appreciated and helped the events run
+smoothly.
 
 ### Supporting Teams
 
@@ -81,6 +94,8 @@ doing in order to make the competition happen. If you’d like to get involved
 
 [slack]: https://studentrobotics.slack.com
 [slack-signup]: https://goo.gl/forms/Maq41MHF8CYSRVn83
+[game-announcement-post]: https://studentrobotics.org/news/2019-10-26-sr2020-kickstart-and-rules-published/
+[two-colours-rules]: https://studentrobotics.org/docs/resources/2020/rulebook.pdf
 [london-tech-day]: https://studentrobotics.org/events/sr2020/london-tech-day-november/
 [tech-day-signup]: https://forms.gle/isHzxAkd7HKKFWGR9
 [mentoring-signup]: https://forms.gle/YHWniHWhuhvBbqg79

--- a/SR2020/2019-11-11-november-update.md
+++ b/SR2020/2019-11-11-november-update.md
@@ -13,14 +13,14 @@ awesome. As ever, if you’d like to get involved please join us in our [Slack][
 
 As you’re probably aware, Kickstart happened at the end of October. At the
 event, which was held simultaneously in three locations, we
-[announced][game-announcement-post] this year's game to the twenty-nine teams
+[announced][game-announcement-post] this year’s game to the twenty-nine teams
 who attended in person.
 
 Our game this year, _Two Colours_, challenges teams to score points by
 retrieving coloured tokens from on and around a raised platform in the centre of
 the arena. They must place these tokens within their scoring zone (i.e. their
 corner of the arena). However, if a team gathers more than one token colour
-within their scoring zone, each token's value drops from 3 points to 1 point.
+within their scoring zone, each token’s value drops from 3 points to 1 point.
 Full details, including the prizes available this year, are available in the
 [rulebook][two-colours-rules].
 

--- a/SR2020/2019-11-11-november-update.md
+++ b/SR2020/2019-11-11-november-update.md
@@ -74,6 +74,9 @@ time, though we won’t ask you to travel further than you feel comfortable.
 If you’d like to get a feel for whether there are any teams near you that you
 might be able to visit, we have a [map of competing teams][teams-map].
 
+Alternatively, some teams will be too far away to visit in person. For those
+teams we would like to be able to provide remote mentoring via video calls.
+
 **[Sign up to mentor a team][mentoring-signup]**.
 
 ### Competition Planning

--- a/SR2020/2019-11-11-november-update.md
+++ b/SR2020/2019-11-11-november-update.md
@@ -83,6 +83,6 @@ doing in order to make the competition happen. If you'd like to get involved
 [slack-signup]: https://goo.gl/forms/Maq41MHF8CYSRVn83
 [london-tech-day]: https://studentrobotics.org/events/sr2020/london-tech-day-november/
 [tech-day-signup]: https://forms.gle/isHzxAkd7HKKFWGR9
-[mentoring-signup]: https://forms.gle/isHzxAkd7HKKFWGR9
+[mentoring-signup]: https://forms.gle/YHWniHWhuhvBbqg79
 [mentor-guidance]: https://srobo.github.io/runbook/volunteering/mentor-guidance/
 [teams-map]: https://drive.google.com/a/studentrobotics.org/open?id=1vEwB5vYNA-KJDnatYtwm7qD9Ewkccd9u

--- a/SR2020/2019-11-11-november-update.md
+++ b/SR2020/2019-11-11-november-update.md
@@ -5,19 +5,19 @@ subject: November Update
 
 Hi all,
 
-Here's a roundup of all the things we're currently working on to make SR2020
-awesome. As ever, if you'd like to get involved please join us in our [Slack][slack]
+Here’s a roundup of all the things we’re currently working on to make SR2020
+awesome. As ever, if you’d like to get involved please join us in our [Slack][slack]
 ([signup form][slack-signup]).
 
 ### Kickstart
 
-As you're probably aware, Kickstart happened at the end of October. A huge
+As you’re probably aware, Kickstart happened at the end of October. A huge
 thank-you to those who helped out, either at one of the venues or with any of
-the preparation. It's much appreciated and helped the events run smoothly.
+the preparation. It’s much appreciated and helped the events run smoothly.
 
 ### Supporting Teams
 
-With the competition year now started, we're organising Tech Days and team
+With the competition year now started, we’re organising Tech Days and team
 Mentoring in order to support the teams as they build their robots.
 
 #### Tech Days
@@ -26,15 +26,15 @@ Tech Days are fairly casual events we host for the teams to spend a day working
 on their robots surrounded by volunteers and other teams. They are and are a
 great opportunity to meet and work with other volunteers as well as see how the
 teams are progressing. Tech Days are all day events (usually on a Saturday),
-though if you can only make a part of the day that's fine.
+though if you can only make a part of the day that’s fine.
 
-There's no need to worry if you don't know much about the kit or the robots --
+There’s no need to worry if you don’t know much about the kit or the robots --
 Tech Days are a great place to learn about both by working alongside other
-volunteers. Just asking the teams to explain what they're working on and
+volunteers. Just asking the teams to explain what they’re working on and
 providing a friendly outside perspective is really helpful.
 
 The next Tech Day is in [London, on Saturday 30th November][london-tech-day] --
-if you'd like to help out, please sign up to **[help at the London Tech Day][tech-day-signup]**.
+if you’d like to help out, please sign up to **[help at the London Tech Day][tech-day-signup]**.
 
 Alternatively, if you think you would like to organise a Tech Day, please
 [email the Competition Team](mailto:competition-team@studentrobotics.org).
@@ -46,8 +46,8 @@ communication and team working skills, as well as help them improve their robot.
 
 Your role as a mentor is to guide the team towards good solutions for their
 robot, provide assistance where they might need it as well as help them
-understand the kit, the rules and the competition as a whole. This doesn't mean
-that you need to know everything about these yourself (it's completely fine not
+understand the kit, the rules and the competition as a whole. This doesn’t mean
+that you need to know everything about these yourself (it’s completely fine not
 to know things!), rather you will guide them towards finding the information for
 themselves.
 
@@ -56,9 +56,9 @@ encourage all potential mentors to read and we will support you through the year
 
 The time commitment for mentoring varies by team, though it is typical to spend
 a few hours every week or fortnight on a mentoring session. This includes travel
-time, though we won't ask you to travel further than you feel comfortable.
+time, though we won’t ask you to travel further than you feel comfortable.
 
-If you'd like to get a feel for whether there are any teams near you that you
+If you’d like to get a feel for whether there are any teams near you that you
 might be able to visit, we have a [map of competing teams][teams-map].
 
 **[Sign up to mentor a team][mentoring-signup]**.
@@ -70,8 +70,8 @@ currently considering two potential venues:
  * University of Reading
  * University of Southampton
 
-Over the next few weeks we'll also be creating a list of the tasks which need
-doing in order to make the competition happen. If you'd like to get involved
+Over the next few weeks we’ll also be creating a list of the tasks which need
+doing in order to make the competition happen. If you’d like to get involved
 (even small contributions really help), please [join us][slack-signup] in our
 [Slack][slack].
 

--- a/SR2020/2019-11-11-november-update.md
+++ b/SR2020/2019-11-11-november-update.md
@@ -36,10 +36,10 @@ Mentoring in order to support the teams as they build their robots.
 #### Tech Days
 
 Tech Days are fairly casual events we host for the teams to spend a day working
-on their robots surrounded by volunteers and other teams. They are and are a
-great opportunity to meet and work with other volunteers as well as see how the
-teams are progressing. Tech Days are all day events (usually on a Saturday),
-though if you can only make a part of the day that’s fine.
+on their robots surrounded by volunteers and other teams. They are a great
+opportunity to meet and work with other volunteers as well as see how the teams
+are progressing. Tech Days are all day events (usually on a Saturday), though if
+you can only make a part of the day that’s fine.
 
 There’s no need to worry if you don’t know much about the kit or the robots --
 Tech Days are a great place to learn about both by working alongside other


### PR DESCRIPTION
This includes a summary of where we're at as well as calls for help to mentor or at the first Tech Day.

Regarding the forms:
 * I'm expecting that the mentoring form will allow people to sign up and then we'll assign them a team
 * I'm expecting that the Tech Day form will allow people to sign up for specific Tech Days and that we'll re-use it for the rest of the SR2020 Tech Days (just altering the options for the first question)

Fixes https://github.com/srobo/competition-team-minutes/issues/176.