### PR TITLE
Add announcement for SR2020 competition date

### DIFF
--- a/SR2020/2019-12-18-competition-date-announcement.md
+++ b/SR2020/2019-12-18-competition-date-announcement.md
@@ -19,6 +19,8 @@ We need some enthusiastic volunteers to help inspire the younger generation, and
 
 ## Tech Days in 2020
 
+Tech Days are opportunities for teams to spend a whole day working on their robot with lots of help available. They’re also an opportunity to see how other teams are doing or get more direct help with your robots.
+
 We have now confirmed the dates of some of the Tech Days in 2020.
 These will be in Thread's offices at 1 Alie Street in London, on the following
 Saturdays next year:

--- a/SR2020/2019-12-18-competition-date-announcement.md
+++ b/SR2020/2019-12-18-competition-date-announcement.md
@@ -19,7 +19,7 @@ We need some enthusiastic volunteers to help inspire the younger generation, and
 
 ## Tech Days in 2020
 
-Tech Days are opportunities for teams to spend a whole day working on their robot with lots of help available. They’re also an opportunity to see how other teams are doing or get more direct help with your robots.
+Tech Days are opportunities for teams to spend a whole day working on their robot with lots of help available. They’re also an opportunity to see how other teams are doing or get more direct help with their robots.
 
 We have now confirmed the dates of some of the Tech Days in 2020.
 These will be in Thread's offices at 1 Alie Street in London, on the following

--- a/SR2020/2019-12-18-competition-date-announcement.md
+++ b/SR2020/2019-12-18-competition-date-announcement.md
@@ -1,0 +1,18 @@
+---
+to: All Volunteers
+subject: SR2020 Competition Date Announcement and Sign up
+---
+
+Hello There!
+
+As an early Christmas present to you all, today's the day we confirm the date for the Student Robotics 2020 competition!
+
+The competition will be held from *Saturday 18th April* until *Sunday 19th April*. The competition will be held at the University of Reading.
+
+[Competition details](https://studentrobotics.org/events/sr2020/competition/)
+
+We're expecting 38 teams, filling out this brand new (to us) venue, and we need some enthusiastic volunteers to help inspire the younger generation, and keep this event running as smooth as possible.
+
+If you think you're up for it, sign up now! Also, please feel free to forward this email to all others you think can help out. The more, the merrier!
+
+[Sign Up Now!](https://forms.gle/iN1CVf7sS5dT537TA)

--- a/SR2020/2019-12-18-competition-date-announcement.md
+++ b/SR2020/2019-12-18-competition-date-announcement.md
@@ -7,12 +7,10 @@ Hello There!
 
 As an early Christmas present to you all, today's the day we confirm the date for the Student Robotics 2020 competition!
 
-The competition will be held from *Saturday 18th April* until *Sunday 19th April*. The competition will be held at the University of Reading.
+The competition will be held from *Saturday 18th April* until *Sunday 19th April*, at the University of Reading. We're expecting around 38 teams, filling out this brand new (to us) venue.
 
 [Competition details](https://studentrobotics.org/events/sr2020/competition/)
 
-We're expecting 38 teams, filling out this brand new (to us) venue, and we need some enthusiastic volunteers to help inspire the younger generation, and keep this event running as smooth as possible.
-
-If you think you're up for it, sign up now! Also, please feel free to forward this email to all others you think can help out. The more, the merrier!
+We need some enthusiastic volunteers to help inspire the younger generation, and keep this event running as smooth as possible. If you think you're up for it, sign up now! Also, please feel free to forward this email to all others you think can help out. The more, the merrier!
 
 [Sign Up Now!](https://forms.gle/iN1CVf7sS5dT537TA)


### PR DESCRIPTION
Announce the dates and venue of the competition to teams, and allow them to sign up to volunteer.

(If you have any feedback on the form itself, I suggest using [`#volunteering`](https://studentrobotics.slack.com/archives/CEG05AAG6) rather than this PR)

:ronseal: