### PR TITLE
Retrospectively add this Mentoring and Game Design email from SR2017

### DIFF
--- a/SR2017/2016-09-28-mentoring-game-design.md
+++ b/SR2017/2016-09-28-mentoring-game-design.md
@@ -1,0 +1,55 @@
+---
+to: Potential Volunteers
+subject: Mentoring and Game Design Opportunities
+---
+
+# Help us choose this year's game
+
+Kickstart for SR2017 is almost upon us, and we need to design a game for the
+year.  If you have a game idea, please let us know by emailing the following
+details to <game-design@studentrobotics.org> by the end of the 2nd of October:
+
+* A brief summary of your game (1-3 paragraphs)
+* A diagram of the arena and any props within it (remember to include a legend!)
+* A description of the scoring scheme.
+
+After the submission deadline, your game idea will be presented to volunteers to
+gather ideas on its strengths and weaknesses.  We'll then give you a chance to
+comment on those criticisms, and will then select a game based on all of the
+above.
+
+# Mentor a team
+
+Would you like to mentor a team and help them achieve their full potential in
+this year's competition?  If so, please [register your interest][mentor-signup]
+so that we can put you in touch with the Local Team Coordinator for your area.
+
+In order to mentor, you should have some skills that will help to further a
+team's learning and understanding of engineering, science or team work. For
+example, you may be an engineering or science undergraduate, graduate or
+professional (but please note that this is not an exhaustive list).
+
+As a mentor, you will have a few responsibilities:
+
+* Assisting your team by consulting them about issues they are having, or may
+  have, relating to their involvement in the competition.
+* You will regularly meet with your team.  This will likely be during or close
+  to school hours i.e. 9am-4pm.  If you have a day job, then you should consider
+  whether this commitment will be possible for you.
+* Reporting to your supervisor (your Local Team Coordinator) when you've visited
+  a team, as well as if you're unable to mentor your team for a significant
+  period of time.
+
+There are currently five Local Team Coordinators who each cover a geographical
+area of the country.  They will be responsible for you as a mentor and will
+hopefully be able to arrange social events throughout the year so you can meet
+other mentors.
+
+Think this is something you would like to be involved in?  We are looking to
+allocate a mentor to each of our 54 teams, so we need as many of you to
+volunteer as possible.  Get involved by [filling in this form][mentor-signup]
+and help guide a team to success in this year’s competition!
+
+[mentor-signup]: https://docs.google.com/forms/d/e/1FAIpQLSdF4YNFXLR0jVBiKfaDaEoH49EWdA5NhvgqpDHShskiccWq7w/viewform?c=0&w=1
+
+Many thanks,


### PR DESCRIPTION
This is mostly so we can move the example content out of the Runbook.
Content copied from the email as received.

See also https://github.com/srobo/runbook/pull/109.