### PR TITLE
Add email with link to more detailed signup form

### DIFF
--- a/SR2022/2022-01-20-competition-volunteer-signup.md
+++ b/SR2022/2022-01-20-competition-volunteer-signup.md
@@ -1,6 +1,6 @@
 ---
 to: All Volunteers
-subject: Sign up to volunteer at the competition (full details)
+subject: Help run the SR2022 Competition event (dates finalised)
 ---
 
 Hi,

--- a/SR2022/2022-01-20-competition-volunteer-signup.md
+++ b/SR2022/2022-01-20-competition-volunteer-signup.md
@@ -1,6 +1,6 @@
 ---
 to: All Volunteers
-subject: Help run the SR2022 Competition event (dates finalised)
+subject: Sign up to volunteer at the competition (full details)
 ---
 
 Hi,

--- a/SR2022/2022-03-04-competition-signup-details.md
+++ b/SR2022/2022-03-04-competition-signup-details.md
@@ -1,6 +1,6 @@
 ---
 to: All Volunteers, volunteers@ and those who completed the form before
-subject: More details about volunteering at the competition
+subject: Sign up to volunteer at the competition (full details)
 ---
 
 Hi,

--- a/SR2022/2022-03-04-competition-signup-details.md
+++ b/SR2022/2022-03-04-competition-signup-details.md
@@ -5,7 +5,7 @@ subject: More details about volunteering at the competition
 
 Hi,
 
-As mentioned in a previous email, The [SR2022 Competition](https://studentrobotics.org/events/sr2022/competition/)
+As mentioned in a previous email, the [SR2022 Competition](https://studentrobotics.org/events/sr2022/competition/)
 event will be on the weekend of the 23rd April, in person at Southampton University.
 
 We need some enthusiastic volunteers to help inspire the younger generation, and keep

--- a/SR2022/2022-03-04-competition-signup-details.md
+++ b/SR2022/2022-03-04-competition-signup-details.md
@@ -14,8 +14,11 @@ Also, please feel free to forward this email to all others you think can help ou
 
     [Volunteer at the Competition](https://forms.gle/WJ3ujG9QEPpGEZ4k6)
 
-Note: If you completed a previous form registering your interest, please also complete this form,
-as it collects additional information needed for the competition.
+Thanks to everyone who expressed their interest in helping out earlier in the year,
+the input gathered then has been useful in planning the competition. As we mentioned
+at the time we're now collecting more detailed information about volunteering at the
+event so even if you expressed interest already please do fill in this form to provide
+those details.
 
 We're also looking for people to help organise the competition. Even if you only
 have a small amount of time available, every contribution helps make the event

--- a/SR2022/2022-03-04-competition-signup-details.md
+++ b/SR2022/2022-03-04-competition-signup-details.md
@@ -1,0 +1,25 @@
+---
+to: All Volunteers, volunteers@ and those who completed the form before
+subject: More details about volunteering at the competition
+---
+
+Hi,
+
+As mentioned in a previous email, The [SR2022 Competition](https://studentrobotics.org/events/sr2022/competition/)
+event will be on the weekend of the 23rd April, in person at Southampton University.
+
+We need some enthusiastic volunteers to help inspire the younger generation, and keep
+this event running as smooth as possible. If you think you're up for it, sign up now!
+Also, please feel free to forward this email to all others you think can help out. The more, the merrier!
+
+    [Volunteer at the Competition](https://forms.gle/WJ3ujG9QEPpGEZ4k6)
+
+Note: If you completed a previous form registering your interest, please also complete this form,
+as it collects additional information needed for the competition.
+
+We're also looking for people to help organise the competition. Even if you only
+have a small amount of time available, every contribution helps make the event
+better for the competitors. If you'd like to help, please come along to a
+competition meeting or contact <competiton-team@studentrobotics.org>.
+
+-- SR Competition Team


### PR DESCRIPTION
We did send a previous email, but this one has even more useful information in.

We'll send it to those who completed the previous form, to ensure we have full coverage. As well as the other mailing lists we have.