### PR TITLE
Add announcement email for SR2026

### DIFF
--- a/SR2026/2025-10-22-sr2026-starting.md
+++ b/SR2026/2025-10-22-sr2026-starting.md
@@ -1,0 +1,56 @@
+---
+to: All Volunteers
+subject: Student Robotics 2026 is starting
+---
+
+Hi All,
+
+Organising for Student Robotics 2026 has [begun](https://studentrobotics.org/blog/2025-09-06-sr2026-registration-open/) - and **we need your help** to make it happen.
+
+## Kickstart
+
+30 teams from around the UK and Europe are registered and ready for the competition to be [kickstarted](https://studentrobotics.org/events/sr2026/kickstart/) on Saturday November 8th at the University of Southampton.
+
+Kickstart is the event which kicks off a competition year. The structure of the competition and the game rules will be announced and of course any questions you have will be answered.
+
+If you're around, it's a great way to learn about the upcoming competition, and get involved in organising it. If you're around, please come along!
+
+## Get involved
+
+There's loads of ways to help with SR2026, taking as much or as little time as you can give.
+
+- The physical competition needs a small army of volunteers to run in numerous technical and non technical roles. We'll open sign ups for volunteering at the event as soon as we can confirm the venue
+- Throughout the year there's lots of preparation to do for the competition and other events, with tasks big & small where any help is welcome. The [Areas](#areas) format from previous years is still here. To help with any of these, be sure to join our Weekly Forum (Wednesdays at 19:30)
+- We're on the look out for mentors, who would regularly attend a teams' meetings (either virtually on in person) and assist them. We'll be opening up expressions of interest shortly after kickstart
+- We'll be running Tech Days and in person events which will need people to help run. We're aiming to be running around one a month, and will be announcing dates and locations at kickstart.
+
+Keep an eye on your inboxes for information about these opportunities as details are announced!
+
+### Areas
+
+Running Student Robotics is no small feat so to help spread the load we've allocated ["area owners"](https://studentrobotics.org/runbook/programme/area-owners/), each responsible for their own part of the competition.
+
+This year, the charity has reorganised around these areas, rather than having both Areas and Committees. There's now just a single committee, with Area Owners. Things are still transitioning, but the aim is to improve efficiency and momentum.
+
+This year there are the following areas:
+
+- Livestream & Production
+- Volunteer Coordination
+- Kit Maintenance
+- Area Logistics
+- Game
+- Team Support
+- Marketing
+- Fundraising
+- Infrastructure
+
+If you want to help out throughout the year, the Weekly Forum is the best place to start - Wednesdays at 19:30. Here, area owners give updates on how their areas are progressing, ask for help, and generally push the competition forwards. If you're interested in helping out with a specific area, feel free to reach out to an area owner directly instead. **No prior experience is necessary**, just a can do attitude!
+
+## Stay up to date
+
+If you want to keep up to date with the latest happenings in Student Robotics then you can [join our Slack](https://forms.gle/DsM45qByLA3heZELA). Most planning and ad-hoc communication occurs there and you'll be able to get stuck in if you want to! Events and meetings can be found on our [calendar](https://studentrobotics.org/runbook/volunteering/calendars/).
+
+You could also subscribe to [SR(A)WN](https://studentrobotics.org/srawn/), our (almost) Weekly Newsletter. This contains headline updates from each Team and can be subscribed to via [RSS](https://studentrobotics.org/srawn/rss.xml) or [Google Groups](https://groups.google.com/g/srawn).
+
+Thanks,
+-- SR Committee (Alex, Jake & Will)


### PR DESCRIPTION
## Summary

Send an email to volunteers to tell them about SR2026. It's not got all the details announced at kickstart, but it's aimed to drum up engagement in organising the competition.

## Checklist

- [x] Has front-matter (`to` and `subject`)
- [x] Compared to a similar email from the previous year
- [x] Ensured there's enough context for a new volunteer to understand
