### PR TITLE
Add email giving information about upcoming events

### DIFF
--- a/SR2026/2026-01-15-sr2026-events.md
+++ b/SR2026/2026-01-15-sr2026-events.md
@@ -5,9 +5,9 @@ subject: Student Robotics 2026 Upcoming Events
 
 Hi All,
 
-The competition is well underway now. This year, in The Neutral Zone, teams are tasked with sorting out some mixed up chemicals. Their mission is to collect and catalogue samples, being careful which ones they collect. But when working with strong chemicals, care must be taken. If teams get acidic and basic samples too close together, they’ll react and neutralise each other, making them worthless. Feel free to check out [the rulebook](https://studentrobotics.org/docs/rules/) for the exact details.
+The competition is well underway now. This year the game is The Neutral Zone, where teams are tasked with sorting out some mixed up chemicals. Their mission is to collect and catalogue samples, being careful which ones they collect. But when working with strong chemicals, care must be taken. If teams get acidic and basic samples too close together, they’ll react and neutralise each other, making them worthless. Feel free to check out [the rulebook](https://studentrobotics.org/docs/rules/) for the exact details.
 
-Teams are building their robots and submitting challenges, communicating with their teammates and other teams in our Discord. A big thanks to Karina for their work overhauling our Discord Bot to make creating and managing guilds that much simpler.
+Teams are building their robots and submitting challenges, communicating with their teammates and other teams in our Discord. 
 
 ## Challenge Days
 

--- a/SR2026/2026-01-15-sr2026-events.md
+++ b/SR2026/2026-01-15-sr2026-events.md
@@ -1,0 +1,40 @@
+---
+to: All Volunteers
+subject: Student Robotics 2026 Upcoming Events
+---
+
+Hi All,
+
+The competition is well underway now. This year, in The Neutral Zone, teams are tasked with sorting out some mixed up chemicals. Their mission is to collect and catalogue samples, being careful which ones they collect. But when working with strong chemicals, care must be taken. If teams get acidic and basic samples too close together, they’ll react and neutralise each other, making them worthless. Feel free to check out [the rulebook](https://studentrobotics.org/docs/rules/) for the exact details.
+
+Teams are building their robots and submitting challenges, communicating with their teammates and other teams in our Discord. A big thanks to Karina for their work overhauling our Discord Bot to make creating and managing guilds that much simpler.
+
+## Challenge Days
+
+We've planned 2 Challenge Days for SR2026. Similar to tech days, they're a chance for teams to get in a room and work on their robot with hands-on support from us blueshirts. But unlike tech days, these days are primarily focused around completing and judging challenges. 
+
+We're planning on running 2 Challenge Days:
+
+- [**24th January 2026** - at Raspberry Pi Foundation in Cambridge](https://studentrobotics.org/events/sr2026/cambridge-challenge-day-january)
+- [**21st February 2026** - at Red River Software in Horsham](https://studentrobotics.org/events/sr2026/horsham-challenge-day-february)
+
+Anyone is welcome to attend this event, even if you've never volunteered before. If you're interested in attending, please complete [this sign-up form](https://forms.gle/LTUPFRUkXQstYpBz7).
+
+## Competition Dates
+
+We are happy to confirm that [Student Robotics 2026](https://studentrobotics.org/events/sr2026/competition/) will be taking place on **Saturday 11th April to Sunday 12th April** at the University of Southampton Students' Union!
+
+We'll formally collect sign-ups soon, including more details for the schedule for the event.
+
+## Weekly Forum
+
+After a Holiday Hiatus, our Weekly Forum meetings are back. We meet weekly on a Wednesday at 19:30 (UK) to discuss outstanding tasks, review issues and generally progress the competition. It's the best way to get involved with helping organise the competition cycle - **Anyone is welcome**.
+
+## Stay up to date
+
+If you want to keep up to date with the latest happenings in Student Robotics then you can [join our Slack](https://forms.gle/DsM45qByLA3heZELA). Most planning and ad-hoc communication occurs there and you'll be able to get stuck in if you want to! Events and meetings can be found on our [calendar](https://studentrobotics.org/runbook/volunteering/calendars/).
+
+You could also subscribe to [SR(A)WN](https://studentrobotics.org/srawn/), our (almost) Weekly Newsletter. This contains headline updates from each Team and can be subscribed to via [RSS](https://studentrobotics.org/srawn/rss.xml) or [Google Groups](https://groups.google.com/g/srawn).
+
+Thanks,
+-- SR Committee (Alex, Jake & Will)


### PR DESCRIPTION
## Summary

Send an email to all volunteers with details of upcoming events (challenge days and the competition).

Copied almost directly from https://github.com/srobo/srawn/pull/89

## Checklist

<!-- Please keep all of these, ~strike~ any which don't apply -->

- [ ] Has front-matter (`to` and `subject`)
- [ ] Compared to a similar email from the previous year
- [ ] Ensured there's enough context for a new volunteer to understand
